### PR TITLE
Added RobotLoader::excludeDirectory(), docs

### DIFF
--- a/tests/Loaders/RobotLoader.phpt
+++ b/tests/Loaders/RobotLoader.phpt
@@ -19,6 +19,7 @@ $loader->addDirectory(__DIR__ . '/file/interface.php'); // as file
 $loader->addDirectory(__DIR__ . '/file/class.const.php');
 $loader->addDirectory(__DIR__ . '/file/trait.php');
 $loader->addDirectory(__DIR__ . '/files.robots');
+$loader->excludeDirectory(__DIR__ . '/files/exclude');
 $loader->register();
 
 Assert::false(class_exists('ConditionalClass'));   // files/conditional.class.php
@@ -38,3 +39,5 @@ Assert::false(class_exists('Disallowed4'));   // files.robots\subdir\disallowed4
 Assert::false(class_exists('Disallowed5'));   // files.robots\subdir\subdir2\disallowed5\class.php
 Assert::false(class_exists('Disallowed6'));   // files.robots\subdir\subdir2\class.php
 Assert::true(class_exists('Allowed2'));       // files.robots\subdir\subdir2\allowed.php
+
+Assert::false(class_exists('ExcludedClass')); // files/exclude/excluded.php

--- a/tests/Loaders/files/exclude/excluded.php
+++ b/tests/Loaders/files/exclude/excluded.php
@@ -1,0 +1,4 @@
+<?php
+
+class ExcludedClass
+{}


### PR DESCRIPTION
FR #8

> A $loader->disallow($path) function would be nice to have, and less awkward than creating a file to instruct the loader which paths to disallow.

I also think it is useful for it is more intuitive than using `netterobots.txt`. A few months ago I needed to do the same thing and because my only documentation was API reference at the time, I did not know about possibility to use `netterobots.txt` and I had to move that directory to an other place.