### PR TITLE
changed namespace of Finder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 	"require": {
 		"php": ">=5.6.0",
 		"ext-tokenizer": "*",
-		"nette/finder": "^2.3 || ^3.0",
+		"nette/finder": "^3.0",
 		"nette/utils": "^2.4 || ^3.0"
 	},
 	"require-dev": {
@@ -25,7 +25,8 @@
 		"tracy/tracy": "^2.3"
 	},
 	"conflict": {
-		"nette/nette": "<2.2"
+		"nette/nette": "<2.2",
+		"nette/finder": "<3.0"
 	},
 	"autoload": {
 		"classmap": ["src/"]

--- a/src/RobotLoader/RobotLoader.php
+++ b/src/RobotLoader/RobotLoader.php
@@ -8,6 +8,7 @@
 namespace Nette\Loaders;
 
 use Nette;
+use Nette\Files\Finder;
 use SplFileInfo;
 
 
@@ -221,7 +222,7 @@ class RobotLoader
 			}
 		}
 
-		$iterator = Nette\Utils\Finder::findFiles(is_array($this->acceptFiles) ? $this->acceptFiles : preg_split('#[,\s]+#', $this->acceptFiles))
+		$iterator = Finder::findFiles(is_array($this->acceptFiles) ? $this->acceptFiles : preg_split('#[,\s]+#', $this->acceptFiles))
 			->filter(function (SplFileInfo $file) use (&$disallow) {
 				return !isset($disallow[str_replace('\\', '/', $file->getPathname())]);
 			})


### PR DESCRIPTION
I've just updated to newest dev version of Nette and my sandbox application's RobotLoader has failed for there is a conflict in namespace of Finder class. In 2.4 it was in `Nette\Utils` but in 3.0 it is in `Nette\Files`.