### PR TITLE
RobotLoader: Fixed the empty variadic array in addDirectory() and excludeDirectory() [Closes #17]

### DIFF
--- a/src/RobotLoader/RobotLoader.php
+++ b/src/RobotLoader/RobotLoader.php
@@ -122,7 +122,7 @@ class RobotLoader
 	 */
 	public function addDirectory(...$paths): self
 	{
-		if (is_array($paths[0])) {
+		if (is_array($paths[0] ?? null)) {
 			trigger_error(__METHOD__ . '() use variadics ...$paths to add an array of paths.', E_USER_WARNING);
 			$paths = $paths[0];
 		}
@@ -144,7 +144,7 @@ class RobotLoader
 	 */
 	public function excludeDirectory(...$paths): self
 	{
-		if (is_array($paths[0])) {
+		if (is_array($paths[0] ?? null)) {
 			trigger_error(__METHOD__ . '() use variadics ...$paths to add an array of paths.', E_USER_WARNING);
 			$paths = $paths[0];
 		}

--- a/tests/Loaders/RobotLoader.emptyArrayVariadicArgument.phpt
+++ b/tests/Loaders/RobotLoader.emptyArrayVariadicArgument.phpt
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Test: Nette\Loaders\RobotLoader bug # 17 POC.
+ */
+
+declare(strict_types=1);
+
+use Nette\Loaders\RobotLoader;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+$loader = new RobotLoader;
+$loader->setTempDirectory(TEMP_DIR);
+
+Assert::noError(
+	function () use ($loader) {
+		$loader->addDirectory(...[]);
+	}
+);
+
+Assert::noError(
+	function () use ($loader) {
+		$loader->excludeDirectory(...[]);
+	}
+);


### PR DESCRIPTION
- bug fix #17
- BC break? no
